### PR TITLE
Make use of display trait implementation instead of manually exposing the to_string method

### DIFF
--- a/src/fractional_index.rs
+++ b/src/fractional_index.rs
@@ -22,7 +22,7 @@ impl FractionalIndex {
 
 impl Display for FractionalIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.inner)
+        write!(f, "{}", self.inner.to_string())
     }
 }
 

--- a/src/fractional_index.rs
+++ b/src/fractional_index.rs
@@ -1,0 +1,39 @@
+use std::fmt::Display;
+
+/// Wrapper for `loro::FractionalIndex`
+#[derive(Debug, Clone)]
+pub struct FractionalIndex {
+    inner: loro::FractionalIndex,
+}
+
+impl FractionalIndex {
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self {
+            inner: loro::FractionalIndex::from_bytes(bytes),
+        }
+    }
+
+    pub fn from_hex_string(str: &str) -> Self {
+        Self {
+            inner: loro::FractionalIndex::from_hex_string(str),
+        }
+    }
+}
+
+impl Display for FractionalIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl From<loro::FractionalIndex> for FractionalIndex {
+    fn from(inner: loro::FractionalIndex) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<FractionalIndex> for loro::FractionalIndex {
+    fn from(wrapper: FractionalIndex) -> Self {
+        wrapper.inner
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub use loro::{
     cursor::{PosType, Side},
     undo::UndoOrRedo,
     CannotFindRelativePosition, ChangeTravelError, Counter, CounterSpan, EventTriggerKind,
-    ExpandType, FractionalIndex, IdLp, IdSpan, JsonChange, JsonFutureOp, JsonFutureOpWrapper,
+    ExpandType, IdLp, IdSpan, JsonChange, JsonFutureOp, JsonFutureOpWrapper,
     JsonListOp, JsonMapOp, JsonMovableListOp, JsonOp, JsonOpContent, JsonSchema, JsonTextOp,
     JsonTreeOp, Lamport, LoroEncodeError, LoroError, PeerID, StyleConfig, TreeID, UpdateOptions,
     UpdateTimeoutError, ID, LORO_VERSION,
@@ -31,6 +31,8 @@ mod awareness;
 pub use awareness::*;
 mod ephemeral;
 pub use ephemeral::*;
+mod fractional_index;
+pub use fractional_index::*;
 
 // https://github.com/mozilla/uniffi-rs/issues/1372
 pub trait ValueOrContainer: Send + Sync {

--- a/src/loro.udl
+++ b/src/loro.udl
@@ -654,6 +654,7 @@ dictionary ContainerPath{
 
 // ============= CONTAINERS =============
 
+[Traits=(Display)]
 interface LoroText{
     /// Create a new container that is detached from the document.
     ///
@@ -806,9 +807,6 @@ interface LoroText{
 
     /// Get the text in [Delta](https://quilljs.com/docs/delta/) format.
     LoroValue get_richtext_value();
-
-    /// Get the text content of the text container.
-    string to_string();
 
     /// Get the cursor at the given position in the given Unicode position..
     ///
@@ -1957,12 +1955,12 @@ dictionary UpdateOptions{
    boolean use_refined_diff;
 };
 
+[Traits=(Display)]
 interface FractionalIndex{
     [Name=from_bytes]
     constructor(bytes bytes);
     [Name=from_hex_string]
     constructor([ByRef] string str);
-    string to_string();
 };
 
 


### PR DESCRIPTION
This PR delegates to the Display trait implementation for the to_string method rather than directly exposing that method. This allows the C# bindings to build without warning, as the Display trait implementation is properly handled by the bindgen generator where as a simple to_string method will generate a `ToString` method that should be marked as override in c# but because this is just a normal method the dourge generator does not do so. Anyways uniffi has support for the display trait so we should use it anyways, right?