### PR TITLE
Fix compile errors against loro v1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75216d8f99725531a30f7b00901ee154a4f8a9b7f125bfe032e197d4c7ffb8c"
+checksum = "e63def75cde167dbc652d21bc6f56e2dc44ce90a5332eb900c42c51ad0e5ed46"
 dependencies = [
  "enum-as-inner 0.6.1",
  "generic-btree",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70363ea05a9c507fd9d58b65dc414bf515f636d69d8ab53e50ecbe8d27eef90c"
+checksum = "23b4ed29838b513f39424d17f1a4cbfa46b345db5d81e240ec3df26d810bb195"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "loro-ffi"
-version = "1.10.3"
+version = "1.11.1"
 dependencies = [
  "loro",
  "serde_json",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f447044ec3d3ba572623859add3334bd87b84340ee5fdf00315bfee0e3ad3e3f"
+checksum = "fe4d9040942768f57efe9e4b532cd1400fe510e7627acc4c4ea2a1d74eececa9"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78beebc933a33c26495c9a98f05b38bc0a4c0a337ecfbd3146ce1f9437eec71f"
+checksum = "1b4feac38d7422f53b935644647329fa50db4dfa26d9d40190ad7beb722cea73"
 dependencies = [
  "bytes",
  "ensure-cov",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
+use loro::sync::RwLock;
 use loro::StyleConfig;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 #[derive(Default)]
 pub struct Configure(loro::Configure);
@@ -27,7 +27,7 @@ impl Configure {
     }
 
     pub fn text_style_config(&self) -> Arc<StyleConfigMap> {
-        Arc::new(StyleConfigMap(self.0.text_style_config().clone()))
+        Arc::new(StyleConfigMap(Arc::clone(self.0.text_style_config())))
     }
 }
 
@@ -40,11 +40,11 @@ impl StyleConfigMap {
     }
 
     pub fn insert(&self, key: &str, value: StyleConfig) {
-        self.0.write().unwrap().insert(key.into(), value);
+        self.0.write().insert(key.into(), value);
     }
 
     pub fn get(&self, key: &str) -> Option<StyleConfig> {
-        let m = self.0.read().unwrap();
+        let m = self.0.read();
         m.get(&(key.into()))
     }
 
@@ -55,7 +55,7 @@ impl StyleConfigMap {
     }
 
     pub(crate) fn to_loro(&self) -> loro::StyleConfigMap {
-        self.0.read().unwrap().clone()
+        self.0.read().clone()
     }
 }
 

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -46,9 +46,9 @@ impl LoroDoc {
         Arc::new(LoroDoc { doc })
     }
 
-    pub fn fork_at(&self, frontiers: &Frontiers) -> Arc<Self> {
-        let doc = self.doc.fork_at(&frontiers.into());
-        Arc::new(LoroDoc { doc })
+    pub fn fork_at(&self, frontiers: &Frontiers) -> LoroResult<Arc<Self>> {
+        let doc = self.doc.fork_at(&frontiers.into())?;
+        Ok(Arc::new(LoroDoc { doc }))
     }
 
     /// Get the configurations of the document.

--- a/src/loro.udl
+++ b/src/loro.udl
@@ -117,6 +117,7 @@ interface LoroDoc{
     /// Fork the document at the given frontiers.
     ///
     /// The created doc will only contain the history before the specified frontiers.
+    [Throws=LoroError]
     LoroDoc fork_at([ByRef] Frontiers frontiers);
 
     /// Get the configurations of the document.


### PR DESCRIPTION
- loro::LoroDoc::fork_at now returns LoroResult<LoroDoc>; propagate the error through loro-ffi's fork_at and mark it [Throws=LoroError] in the UDL.
- Configure::text_style_config now returns &Arc<loro::sync::RwLock<_>> instead of std::sync::RwLock; switch StyleConfigMap to wrap the loro::sync::RwLock (whose read/write don't return Result).