### PR TITLE
Update loro-ffi binding to the latest uniffi version (v0.31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "loro"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75216d8f99725531a30f7b00901ee154a4f8a9b7f125bfe032e197d4c7ffb8c"
+checksum = "e63def75cde167dbc652d21bc6f56e2dc44ce90a5332eb900c42c51ad0e5ed46"
 dependencies = [
  "enum-as-inner 0.6.1",
  "generic-btree",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "loro-common"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70363ea05a9c507fd9d58b65dc414bf515f636d69d8ab53e50ecbe8d27eef90c"
+checksum = "23b4ed29838b513f39424d17f1a4cbfa46b345db5d81e240ec3df26d810bb195"
 dependencies = [
  "arbitrary",
  "enum-as-inner 0.6.1",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "loro-ffi"
-version = "1.10.3"
+version = "1.11.1"
 dependencies = [
  "loro",
  "serde_json",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "loro-internal"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f447044ec3d3ba572623859add3334bd87b84340ee5fdf00315bfee0e3ad3e3f"
+checksum = "fe4d9040942768f57efe9e4b532cd1400fe510e7627acc4c4ea2a1d74eececa9"
 dependencies = [
  "append-only-bytes",
  "arref",
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "loro-kv-store"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78beebc933a33c26495c9a98f05b38bc0a4c0a337ecfbd3146ce1f9437eec71f"
+checksum = "1b4feac38d7422f53b935644647329fa50db4dfa26d9d40190ad7beb722cea73"
 dependencies = [
  "bytes",
  "ensure-cov",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,54 +25,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
 
 [[package]]
 name = "anyhow"
@@ -109,43 +65,44 @@ checksum = "2ccd462b64c3c72f1be8305905a85d85403d768e8690c9b8bd3b9009a5761679"
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
- "askama_escape",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "serde",
+ "serde_derive",
  "syn 2.0.101",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -168,15 +125,6 @@ name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -243,16 +191,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -286,7 +234,6 @@ version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
- "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -315,12 +262,6 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cpufeatures"
@@ -476,6 +417,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,10 +625,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
+name = "indexmap"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "itertools"
@@ -718,6 +687,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -780,7 +755,7 @@ dependencies = [
  "serde",
  "serde_columnar",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -844,7 +819,7 @@ dependencies = [
  "serde_columnar",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "thread_local",
  "tracing",
  "wasm-bindgen",
@@ -925,22 +900,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -1054,12 +1013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,10 +1042,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "percent-encoding"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1198,7 +1151,7 @@ checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
 dependencies = [
  "ahash",
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
  "parking_lot",
 ]
 
@@ -1325,6 +1278,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,10 +1345,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1396,7 +1363,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_columnar_derive",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1412,10 +1379,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1432,6 +1408,15 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1462,9 +1447,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sized-chunks"
@@ -1541,6 +1526,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1553,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1563,6 +1570,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1581,12 +1599,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1672,12 +1720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,9 +1727,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "uniffi"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
 dependencies = [
  "anyhow",
  "camino",
@@ -1697,13 +1739,14 @@ dependencies = [
  "uniffi_build",
  "uniffi_core",
  "uniffi_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
 dependencies = [
  "anyhow",
  "askama",
@@ -1713,20 +1756,23 @@ dependencies = [
  "glob",
  "goblin",
  "heck 0.5.0",
+ "indexmap",
  "once_cell",
- "paste",
  "serde",
+ "tempfile",
  "textwrap",
  "toml",
+ "uniffi_internal_macros",
  "uniffi_meta",
+ "uniffi_pipeline",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
 dependencies = [
  "anyhow",
  "camino",
@@ -1734,36 +1780,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_checksum_derive"
-version = "0.28.3"
+name = "uniffi_core"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
 dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
  "quote",
  "syn 2.0.101",
 ]
 
 [[package]]
-name = "uniffi_core"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
-dependencies = [
- "anyhow",
- "bytes",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
-]
-
-[[package]]
 name = "uniffi_macros"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
 dependencies = [
- "bincode",
  "camino",
  "fs-err",
  "once_cell",
@@ -1777,47 +1823,40 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
 dependencies = [
  "anyhow",
- "bytes",
  "siphasher",
- "uniffi_checksum_derive",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
-name = "uniffi_testing"
-version = "0.28.3"
+name = "uniffi_pipeline"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
 dependencies = [
  "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "once_cell",
+ "heck 0.5.0",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
- "uniffi_testing",
  "weedle2",
 ]
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -2124,6 +2163,21 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ path = "src/uniffi-bindgen.rs"
 [dependencies]
 loro = { version = "1.11.1", features = ["counter", "jsonpath"] }
 serde_json = { version = "1" }
-uniffi = { version = "0.28.3" }
+uniffi = { version = "0.31.1" }
 
 [build-dependencies]
-uniffi = { version = "0.28.3", features = ["build"] }
+uniffi = { version = "0.31.1", features = ["build"] }
 
 [features]
 cli = ["uniffi/cli"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use loro::sync::RwLock;
 use loro::StyleConfig;
-use loro::sync::RwLock;
 use std::sync::Arc;
 
 #[derive(Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use loro::StyleConfig;
+use loro::sync::RwLock;
 use std::sync::Arc;
-use std::sync::RwLock;
 
 #[derive(Default)]
 pub struct Configure(loro::Configure);
@@ -40,11 +40,11 @@ impl StyleConfigMap {
     }
 
     pub fn insert(&self, key: &str, value: StyleConfig) {
-        self.0.write().unwrap().insert(key.into(), value);
+        self.0.write().insert(key.into(), value);
     }
 
     pub fn get(&self, key: &str) -> Option<StyleConfig> {
-        let m = self.0.read().unwrap();
+        let m = self.0.read();
         m.get(&(key.into()))
     }
 
@@ -55,7 +55,7 @@ impl StyleConfigMap {
     }
 
     pub(crate) fn to_loro(&self) -> loro::StyleConfigMap {
-        self.0.read().unwrap().clone()
+        self.0.read().clone()
     }
 }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -16,6 +16,7 @@ pub use unknown::LoroUnknown;
 
 use crate::{ContainerID, ContainerType};
 
+#[uniffi::trait_interface]
 pub trait ContainerIdLike: Send + Sync {
     fn as_container_id(&self, ty: ContainerType) -> ContainerID;
 }

--- a/src/container/map.rs
+++ b/src/container/map.rs
@@ -71,7 +71,6 @@ impl LoroMap {
             .map(|v| Arc::new(v) as Arc<dyn ValueOrContainer>)
     }
 
-    // TODO: uniffi v0.29
     pub fn get_or_create_text_container(
         &self,
         key: &str,

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -394,7 +394,6 @@ impl LoroDoc {
             .collect()
     }
 
-    // TODO: add export method
     /// Export all the ops not included in the given `VersionVector`
     #[inline]
     pub fn export_updates(&self, vv: &VersionVector) -> Result<Vec<u8>, LoroEncodeError> {
@@ -662,11 +661,11 @@ impl LoroDoc {
         self.doc.compact_change_store()
     }
 
-    // TODO: https://github.com/mozilla/uniffi-rs/issues/1372
     /// Export the document in the given mode.
-    // pub fn export(&self, mode: ExportMode) -> Vec<u8> {
-    //     self.doc.export(mode.into())
-    // }
+    pub fn export(&self, mode: ExportMode) -> Result<Vec<u8>, LoroEncodeError> {
+        self.doc.export(mode.into())
+    }
+
     pub fn export_updates_in_range(&self, spans: &[IdSpan]) -> Result<Vec<u8>, LoroEncodeError> {
         self.doc.export(loro::ExportMode::UpdatesInRange {
             spans: Cow::Borrowed(spans),
@@ -1070,33 +1069,37 @@ pub struct PosQueryResult {
     pub current: AbsolutePosition,
 }
 
-// pub enum ExportMode {
-//     Snapshot,
-//     Updates { from: VersionVector },
-//     UpdatesInRange { spans: Vec<IdSpan> },
-//     ShallowSnapshot { frontiers: Frontiers },
-//     StateOnly { frontiers: Option<Frontiers> },
-// }
+pub enum ExportMode {
+    Snapshot,
+    Updates { from: Arc<VersionVector> },
+    UpdatesInRange { spans: Vec<IdSpan> },
+    ShallowSnapshot { frontiers: Arc<Frontiers> },
+    StateOnly { frontiers: Option<Arc<Frontiers>> },
+    SnapshotAt { frontiers: Arc<Frontiers> },
+}
 
-// impl From<ExportMode> for loro::ExportMode<'_> {
-//     fn from(value: ExportMode) -> Self {
-//         match value {
-//             ExportMode::Snapshot => loro::ExportMode::Snapshot,
-//             ExportMode::Updates { from } => loro::ExportMode::Updates {
-//                 from: Cow::Owned(from.into()),
-//             },
-//             ExportMode::UpdatesInRange { spans } => loro::ExportMode::UpdatesInRange {
-//                 spans: Cow::Owned(spans),
-//             },
-//             ExportMode::ShallowSnapshot { frontiers } => {
-//                 loro::ExportMode::ShallowSnapshot(Cow::Owned(frontiers.into()))
-//             }
-//             ExportMode::StateOnly { frontiers } => {
-//                 loro::ExportMode::StateOnly(frontiers.map(|x| Cow::Owned(x.into())))
-//             }
-//         }
-//     }
-// }
+impl From<ExportMode> for loro::ExportMode<'static> {
+    fn from(value: ExportMode) -> Self {
+        match value {
+            ExportMode::Snapshot => loro::ExportMode::Snapshot,
+            ExportMode::Updates { from } => loro::ExportMode::Updates {
+                from: Cow::Owned(from.as_ref().into()),
+            },
+            ExportMode::UpdatesInRange { spans } => loro::ExportMode::UpdatesInRange {
+                spans: Cow::Owned(spans),
+            },
+            ExportMode::ShallowSnapshot { frontiers } => {
+                loro::ExportMode::ShallowSnapshot(Cow::Owned(frontiers.as_ref().into()))
+            }
+            ExportMode::StateOnly { frontiers } => loro::ExportMode::StateOnly(
+                frontiers.map(|x| Cow::Owned(x.as_ref().into())),
+            ),
+            ExportMode::SnapshotAt { frontiers } => loro::ExportMode::SnapshotAt {
+                version: Cow::Owned(frontiers.as_ref().into()),
+            },
+        }
+    }
+}
 
 pub struct ContainerPath {
     pub id: ContainerID,

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -46,9 +46,9 @@ impl LoroDoc {
         Arc::new(LoroDoc { doc })
     }
 
-    pub fn fork_at(&self, frontiers: &Frontiers) -> Arc<Self> {
-        let doc = self.doc.fork_at(&frontiers.into());
-        Arc::new(LoroDoc { doc })
+    pub fn fork_at(&self, frontiers: &Frontiers) -> LoroResult<Arc<Self>> {
+        let doc = self.doc.fork_at(&frontiers.into())?;
+        Ok(Arc::new(LoroDoc { doc }))
     }
 
     /// Get the configurations of the document.

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -876,6 +876,7 @@ impl LoroDoc {
     }
 }
 
+#[uniffi::trait_interface]
 pub trait ChangeAncestorsTraveler: Sync + Send {
     fn travel(&self, change: ChangeMeta) -> bool;
 }
@@ -986,14 +987,17 @@ impl<T: TryInto<JsonSchema> + Clone> JsonSchemaLike for T {
     }
 }
 
+#[uniffi::trait_interface]
 pub trait JsonPathSubscriber: Sync + Send {
     fn on_jsonpath_changed(&self);
 }
 
+#[uniffi::trait_interface]
 pub trait LocalUpdateCallback: Sync + Send {
     fn on_local_update(&self, update: Vec<u8>);
 }
 
+#[uniffi::trait_interface]
 pub trait FirstCommitFromPeerCallback: Sync + Send {
     fn on_first_commit_from_peer(&self, e: FirstCommitFromPeerPayload);
 }
@@ -1002,6 +1006,7 @@ pub struct FirstCommitFromPeerPayload {
     pub peer: PeerID,
 }
 
+#[uniffi::trait_interface]
 pub trait PreCommitCallback: Sync + Send {
     fn on_pre_commit(&self, e: PreCommitCallbackPayload);
 }
@@ -1023,6 +1028,7 @@ impl ChangeModifier {
     }
 }
 
+#[uniffi::trait_interface]
 pub trait Unsubscriber: Sync + Send {
     fn on_unsubscribe(&self);
 }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -11,10 +11,12 @@ pub struct EphemeralStoreEvent {
     pub updated: Vec<String>,
 }
 
+#[uniffi::trait_interface]
 pub trait LocalEphemeralListener: Sync + Send {
     fn on_ephemeral_update(&self, update: Vec<u8>);
 }
 
+#[uniffi::trait_interface]
 pub trait EphemeralSubscriber: Sync + Send {
     fn on_ephemeral_event(&self, event: EphemeralStoreEvent);
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,6 +10,7 @@ use crate::{
     convert_trait_to_v_or_container, ContainerID, LoroValue, TreeParentId, ValueOrContainer,
 };
 
+#[uniffi::trait_interface]
 pub trait Subscriber: Sync + Send {
     fn on_diff(&self, diff: DiffEvent);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub use ephemeral::*;
 mod fractional_index;
 pub use fractional_index::*;
 
-// https://github.com/mozilla/uniffi-rs/issues/1372
 #[uniffi::trait_interface]
 pub trait ValueOrContainer: Send + Sync {
     fn is_value(&self) -> bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod fractional_index;
 pub use fractional_index::*;
 
 // https://github.com/mozilla/uniffi-rs/issues/1372
+#[uniffi::trait_interface]
 pub trait ValueOrContainer: Send + Sync {
     fn is_value(&self) -> bool;
     fn is_container(&self) -> bool;

--- a/src/loro.udl
+++ b/src/loro.udl
@@ -661,6 +661,7 @@ interface LoroDoc{
     void delete_root_container(ContainerID cid);
 };
 
+[Remote]
 dictionary ContainerPath{
     ContainerID id;
     Index path;
@@ -1006,7 +1007,6 @@ interface LoroMap{
     /// Get the value of the map with the given key.
     ValueOrContainer? get([ByRef] string key);
 
-    // TODO: uniffi v0.29
     [Throws=LoroError]
     LoroList get_or_create_list_container([ByRef] string key, LoroList child);
     [Throws=LoroError]
@@ -1438,6 +1438,7 @@ interface LoroUnknown{
 //     StateOnly(Frontiers? frontiers);
 // };
 
+[Remote]
 dictionary ChangeMeta{
     /// Lamport timestamp of the Change
     u32 lamport;
@@ -1454,6 +1455,7 @@ dictionary ChangeMeta{
     u32 len;
 };
 
+[Remote]
 dictionary ImportBlobMetadata{
     /// The partial start version vector.
     ///
@@ -1474,21 +1476,25 @@ dictionary ImportBlobMetadata{
     string mode;
 };
 
+[Remote]
 dictionary ImportStatus{
     record<u64, CounterSpan> success;
     record<u64, CounterSpan>? pending;
 };
 
+[Remote]
 enum Ordering{
     "Less", "Equal", "Greater"
 };
 
+[Remote]
 dictionary PreCommitCallbackPayload{
     ChangeMeta change_meta;
     string origin;
     ChangeModifier modifier;
 };
 
+[Remote]
 dictionary FirstCommitFromPeerPayload{
     u64 peer;
 };
@@ -1517,10 +1523,12 @@ interface StyleConfigMap{
     StyleConfig? get([ByRef] string key);
 };
 
+[Remote]
 dictionary StyleConfig{
     ExpandType expand;
 };
 
+[Remote]
 enum ExpandType{
     "Before",
     "After",
@@ -1528,6 +1536,7 @@ enum ExpandType{
     "None",
 };
 
+[Remote]
 dictionary CommitOptions{
     string? origin;
     boolean immediate_renew;
@@ -1538,12 +1547,14 @@ dictionary CommitOptions{
 // ============= CURSOR =============
 
 
+[Remote]
 enum Side{
     "Left",
     "Middle",
     "Right",
 };
 
+[Remote]
 enum PosType{
     "Bytes",
     "Unicode",
@@ -1559,11 +1570,13 @@ interface Cursor{
     constructor([ByRef]bytes data);
 };
 
+[Remote]
 dictionary PosQueryResult{
     Cursor? update;
     AbsolutePosition current;
 };
 
+[Remote]
 dictionary AbsolutePosition{
     u32 pos;
     Side side;
@@ -1582,11 +1595,13 @@ interface Awareness{
     u64 peer();
 };
 
+[Remote]
 dictionary AwarenessPeerUpdate{
     sequence<u64> updated;
     sequence<u64> added;
 };
 
+[Remote]
 dictionary PeerInfo{
     LoroValue state;
     i32 counter;
@@ -1609,6 +1624,7 @@ interface EphemeralStore{
     Subscription subscribe(EphemeralSubscriber listener);
 };
 
+[Remote]
 dictionary EphemeralStoreEvent{
     EphemeralEventTrigger by;
     sequence<string> added;
@@ -1616,6 +1632,7 @@ dictionary EphemeralStoreEvent{
     sequence<string> updated;
 };
 
+[Remote]
 enum EphemeralEventTrigger{
     "Local", 
     "Import", 
@@ -1660,6 +1677,7 @@ interface Frontiers{
     sequence<ID> to_vec();
 };
 
+[Remote]
 dictionary VersionVectorDiff{
     /// need to add these spans to move from right to left
     record<u64, CounterSpan> retreat;
@@ -1709,6 +1727,7 @@ interface VersionRange{
     sequence<VersionRangeItem> get_all_ranges();
 };
 
+[Remote]
 dictionary VersionRangeItem{
     u64 peer;
     i32 start;
@@ -1792,25 +1811,30 @@ interface UndoManager{
     LoroValue? top_redo_value();
 };
 
+[Remote]
 enum UndoOrRedo{
     "Undo", "Redo",
 };
 
+[Remote]
 dictionary CounterSpan{
     i32 start;
     i32 end;
 };
 
+[Remote]
 dictionary UndoItemMeta{
     LoroValue value;
     sequence<CursorWithPos> cursors;
 };
 
+[Remote]
 dictionary CursorWithPos{
     Cursor cursor;
     AbsolutePosition pos;
 };
 
+[Remote]
 dictionary AbsolutePosition{
     u32 pos;
     Side side;
@@ -1818,6 +1842,7 @@ dictionary AbsolutePosition{
 
 // ============= EVENTS =============
 
+[Remote]
 dictionary DiffEvent{
     /// How the event is triggered.
     EventTriggerKind triggered_by;
@@ -1830,6 +1855,7 @@ dictionary DiffEvent{
 };
 
 /// A diff of a container.
+[Remote]
 dictionary ContainerDiff{
     /// The target container id of the diff.
     ContainerID target;
@@ -1870,15 +1896,18 @@ interface ListDiffItem{
     Retain(u32 retain);
 };
 
+[Remote]
 dictionary MapDelta{
     record<string, ValueOrContainer?> updated;
 };
 
+[Remote]
 dictionary TreeDiff{
     sequence<TreeDiffItem> diff;
 };
 
 
+[Remote]
 dictionary TreeDiffItem{
     TreeID target;
     TreeExternalDiff action;
@@ -1891,12 +1920,14 @@ interface TreeExternalDiff{
     Delete(TreeParentId old_parent, u32 old_index);
 };
 
+[Remote]
 dictionary PathItem{
     ContainerID container;
     Index index;
 };
 
 /// The kind of the event trigger.
+[Remote]
 enum EventTriggerKind{
     /// The event is triggered by a local transaction.
     "Local",
@@ -1945,12 +1976,14 @@ interface DiffBatch{
     sequence<ContainerIDAndDiff> get_diff();
 };
 
+[Remote]
 dictionary ContainerIDAndDiff{
     ContainerID cid;
     Diff diff;
 };
 
 // ============= TYPES =============
+[Remote]
 dictionary TreeID{
     u64 peer;
     i32 counter;
@@ -1964,6 +1997,7 @@ interface TreeParentId{
     Unexist();
 };
 
+[Remote]
 dictionary UpdateOptions{
    f64? timeout_ms;
    boolean use_refined_diff;
@@ -1978,21 +2012,25 @@ interface FractionalIndex{
 };
 
 
+[Remote]
 dictionary ID{
     u64 peer;
     i32 counter;
 };
 
+[Remote]
 dictionary IdLp{
     u32 lamport;
     u64 peer;
 };
 
+[Remote]
 dictionary IdSpan{
     u64 peer;
     CounterSpan counter;
 };
 
+[Remote]
 dictionary CounterSpan{
     i32 start;
     i32 end;
@@ -2016,6 +2054,7 @@ interface ContainerID{
     Normal(u64 peer,i32 counter, ContainerType container_type);
 };
 
+[Remote]
 dictionary FrontiersOrID{
     Frontiers? frontiers;
     ID? id;
@@ -2034,7 +2073,7 @@ interface LoroValue{
     Container(ContainerID value);
 };
 
-[Error]
+[Error, Remote]
 enum LoroError {
     "UnmatchedContext",
     "DecodeVersionVectorError",
@@ -2077,33 +2116,33 @@ enum LoroError {
     "UndoGroupAlreadyStarted",
 };
 
-[Error]
+[Error, Remote]
 enum CannotFindRelativePosition{
     "ContainerDeleted",
     "HistoryCleared",
     "IdNotFound"
 };
 
-[Error]
+[Error, Remote]
 enum JsonPathError{
     "InvalidJsonPath",
     "EvaluationError"
 };
 
-[Error, NonExhaustive]
+[Error, NonExhaustive, Remote]
 enum LoroEncodeError{
     "FrontiersNotFound",
     "ShallowSnapshotIncompatibleWithOldFormat",
     "UnknownContainer",
 };
 
-[Error]
+[Error, Remote]
 enum ChangeTravelError{
     "TargetIdNotFound",
     "TargetVersionNotIncluded"
 };
 
-[Error]
+[Error, Remote]
 enum UpdateTimeoutError{
     "Timeout"
 };

--- a/src/loro.udl
+++ b/src/loro.udl
@@ -481,8 +481,9 @@ interface LoroDoc{
     /// The parsed ops will be dropped
     void compact_change_store();
 
-    // /// Export the document in the given mode.
-    // bytes export(ExportMode mode);
+    /// Export the document in the given mode.
+    [Throws=LoroEncodeError]
+    bytes export(ExportMode mode);
 
     [Throws=LoroEncodeError]
     bytes export_updates_in_range([ByRef]sequence<IdSpan> spans);
@@ -1428,15 +1429,15 @@ interface LoroUnknown{
 
 // ============= TYPES =============
 
-// TODO: https://github.com/mozilla/uniffi-rs/issues/1372
-// [Enum]
-// interface ExportMode{
-//     Snapshot();
-//     Updates(VersionVector from);
-//     UpdatesInRange(sequence<IdSpan> spans);
-//     GcSnapshot(Frontiers frontiers);
-//     StateOnly(Frontiers? frontiers);
-// };
+[Enum]
+interface ExportMode{
+    Snapshot();
+    Updates(VersionVector from);
+    UpdatesInRange(sequence<IdSpan> spans);
+    ShallowSnapshot(Frontiers frontiers);
+    StateOnly(Frontiers? frontiers);
+    SnapshotAt(Frontiers frontiers);
+};
 
 [Remote]
 dictionary ChangeMeta{

--- a/src/loro.udl
+++ b/src/loro.udl
@@ -117,6 +117,7 @@ interface LoroDoc{
     /// Fork the document at the given frontiers.
     ///
     /// The created doc will only contain the history before the specified frontiers.
+    [Throws=LoroError]
     LoroDoc fork_at([ByRef] Frontiers frontiers);
 
     /// Get the configurations of the document.

--- a/src/undo.rs
+++ b/src/undo.rs
@@ -130,6 +130,7 @@ impl UndoManager {
     }
 }
 
+#[uniffi::trait_interface]
 pub trait OnPush: Send + Sync {
     fn on_push(
         &self,
@@ -139,6 +140,7 @@ pub trait OnPush: Send + Sync {
     ) -> UndoItemMeta;
 }
 
+#[uniffi::trait_interface]
 pub trait OnPop: Send + Sync {
     fn on_pop(
         &self,

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use loro::{Counter, PeerID};
 
+#[uniffi::trait_interface]
 pub trait LoroValueLike: Sync + Send {
     fn as_loro_value(&self) -> crate::LoroValue;
 }


### PR DESCRIPTION
This PR contains the changes needed from https://github.com/loro-dev/loro-ffi/pull/10. This is done in order to be able to validate compilation